### PR TITLE
Use github actions to auto deploy to github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Deploy Github Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    # Allow one concurrent deployment
+    concurrency:
+      group: 'pages'
+      cancel-in-progress: true
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: ./
+        
+    - name: Deploy to GitHub Pages
+      uses: actions/deploy-pages@v4
+      id: deployment

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+99friday.com

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+https://99friday.com


### PR DESCRIPTION
- github pages needs to be enabled on the repository (if it isn't)
- created a CNAME file, DNS shoud point to github pages
  see item 5: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site
- github actions using the https://github.com/actions/deploy-pages and https://github.com/actions/upload-pages-artifact actions from GitHub
- added README just 'cause
